### PR TITLE
chore: make nft code more debuggable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,6 @@ RUN make build/app
 
 FROM alpine:3.15
 
-RUN apk add tcpdump wireguard-tools
+RUN apk add tcpdump wireguard-tools nftables
 COPY --from=builder /build/tunnel-node /tunnel-node
 CMD ["/tunnel-node"]

--- a/internal/settings/static.go
+++ b/internal/settings/static.go
@@ -72,8 +72,7 @@ type Config struct {
 func (s *Config) GetNetworkAccessPolicy() NetworkAccessPolicy {
 	if s.NetworkPolicy == nil {
 		return NetworkAccessPolicy{
-			// Access: ipam.NetworkAccess{DefaultPolicy: ipam.AliasInternetOnly()},
-			Access: ipam.NetworkAccess{DefaultPolicy: ipam.AliasAllowAll()},
+			Access: ipam.NetworkAccess{DefaultPolicy: ipam.AliasInternetOnly()},
 		}
 	}
 	return *s.NetworkPolicy

--- a/pkg/ipam/nft_linux.go
+++ b/pkg/ipam/nft_linux.go
@@ -50,6 +50,8 @@ func newNetfilter(subnet *xnet.IPNet) netFilter {
 }
 
 func (nft *netfilterWrapper) init() error {
+	zap.L().Debug("init")
+
 	nft.c.FlushRuleset()
 	nft.enableMasquerade()
 	nft.initIsolation()
@@ -99,6 +101,8 @@ func (nft *netfilterWrapper) initIsolation() {
 }
 
 func (nft *netfilterWrapper) newIsolatePeerRule(peerIP xnet.IP) error {
+	zap.L().Debug("isolate peer", zap.String("ip", peerIP.String()))
+
 	/*
 	 +expr.Payload :: &expr.Payload{OperationType:0x0, DestRegister:0x1, SourceRegister:0x0, Base:0x1, Offset:0xc, Len:0x4, CsumType:0x0, CsumOffset:0x0, CsumFlags:0x0}
 	 +expr.Cmp :: &expr.Cmp{Op:0x0, Register:0x1, Data:[]uint8{0xac, 0x11, 0x11, 0xa}}
@@ -173,6 +177,8 @@ func ipnetSizeBytes(ipn *xnet.IPNet) int {
 }
 
 func (nft *netfilterWrapper) newIsolateAllRule(ipNet *xnet.IPNet) error {
+	zap.L().Debug("isolate all", zap.String("ipnet", ipNet.String()))
+
 	subnet := ipNet.IPNet.IP.To4()[:ipnetSizeBytes(ipNet)]
 
 	nft.c.AddRule(&nftables.Rule{
@@ -230,6 +236,8 @@ func (nft *netfilterWrapper) newIsolateAllRule(ipNet *xnet.IPNet) error {
 }
 
 func (nft *netfilterWrapper) findAndRemoveRule(id []byte) error {
+	zap.L().Debug("remove rule", zap.ByteString("id", id))
+
 	chanis, err := nft.c.ListChains()
 	if err != nil {
 		return xerror.EInternalError("nft: failed to list chains", err)


### PR DESCRIPTION
* log nft_linux actions at debug level;
* add `nftables` package to the resulting container, allows us to use `nft list ruleset` inside the container and see wthigo;