### PR TITLE
fix: silence `nft delete rule` errors for the frontend

### DIFF
--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -183,7 +183,12 @@ func (m *IPAM) free(addr xnet.IP) error {
 		//  So this `if` block exists just to contain the following comment. Amen.
 	}
 
-	return m.nf.findAndRemoveRule(addr.IP.To4())
+	if err := m.nf.findAndRemoveRule(addr.IP.To4()); err != nil {
+		// we want to make this rule not exist, and it does not exist so.
+		// problems?
+	}
+
+	return nil
 }
 
 func (m *IPAM) Running() bool {

--- a/pkg/ipam/netfilter.go
+++ b/pkg/ipam/netfilter.go
@@ -7,13 +7,7 @@
 package ipam
 
 import (
-	"errors"
-
 	"github.com/vpnhouse/tunnel/pkg/xnet"
-)
-
-var (
-	errRuleNotFound = errors.New("nft: no rule with given ID were found")
 )
 
 type netFilter interface {

--- a/pkg/ipam/nft_linux.go
+++ b/pkg/ipam/nft_linux.go
@@ -280,7 +280,7 @@ func (nft *netfilterWrapper) findAndRemoveRule(id []byte) error {
 		}
 	}
 
-	return xerror.EInternalError("nft", errRuleNotFound, zap.Any("id", id))
+	return xerror.EInternalError("nft: no rule with given ID were found", nil, zap.Any("id", id))
 }
 
 func listNFTObjects(nft *nftables.Conn) {


### PR DESCRIPTION
the frontend has nothing to do with such errors. But we still keep logging them for diagnostic purposes. 