### PR TITLE
Feature/port blocking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,12 @@ COPY ./frontend /app/
 WORKDIR /app
 RUN npm install && npm run build
 
+from toolset as gomodules
+COPY go.mod /build/
+WORKDIR /build
+RUN go mod download
 
-FROM toolset as builder
+FROM gomodules as builder
 
 COPY . /build
 COPY --from=nodejs /app/dist /build/internal/frontend/dist/

--- a/cmd/tunnel/main.go
+++ b/cmd/tunnel/main.go
@@ -99,10 +99,11 @@ func initServices(runtime *runtime.TunnelRuntime) error {
 	// Initialize ip addr manager
 	netpol := runtime.Settings.GetNetworkAccessPolicy()
 	ipv4am, err := ipam.New(ipam.Config{
-		Subnet:       wgcfg.Subnet.Unwrap(),
-		Interface:    wgcfg.Interface,
-		AccessPolicy: netpol.Access,
-		RateLimiter:  netpol.RateLimit,
+		Subnet:           wgcfg.Subnet.Unwrap(),
+		Interface:        wgcfg.Interface,
+		AccessPolicy:     netpol.Access,
+		RateLimiter:      netpol.RateLimit,
+		PortRestrictions: runtime.Settings.PortRestrictions,
 	})
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-acme/lego/v4 v4.6.0
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/go-chi/cors v1.2.0
-	github.com/google/nftables v0.0.0-20220402130106-19672dc9fe54
+	github.com/google/nftables v0.0.0-20221002140148-535f5eb8da79
 	github.com/google/uuid v1.3.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/jmoiron/sqlx v1.3.4

--- a/go.sum
+++ b/go.sum
@@ -392,6 +392,8 @@ github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIG
 github.com/google/martian/v3 v3.2.1/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
 github.com/google/nftables v0.0.0-20220402130106-19672dc9fe54 h1:KjGHUOTclov7IfvqZXf3w1cSx1Bw1Exbe27/4KvpwHM=
 github.com/google/nftables v0.0.0-20220402130106-19672dc9fe54/go.mod h1:0F8on3JWMkm+xahTHItkiu/E1SPqMd0TOxNweQv8ptE=
+github.com/google/nftables v0.0.0-20221002140148-535f5eb8da79 h1:gHlwshQh1WGK6ghd5f4n3q8tV2/gNN8fp8fjmxKb07U=
+github.com/google/nftables v0.0.0-20221002140148-535f5eb8da79/go.mod h1:b97ulCCFipUC+kSin+zygkvUVpx0vyIAwxXFdY3PlNc=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=

--- a/internal/settings/static.go
+++ b/internal/settings/static.go
@@ -52,17 +52,18 @@ type Config struct {
 	HTTP       HttpConfig       `yaml:"http"`
 
 	// optional configuration
-	ExternalStats      *extstat.Config         `yaml:"external_stats,omitempty"`
-	NetworkPolicy      *NetworkAccessPolicy    `yaml:"network,omitempty"`
-	SSL                *xhttp.SSLConfig        `yaml:"ssl,omitempty"`
-	Domain             *xhttp.DomainConfig     `yaml:"domain,omitempty"`
-	AdminAPI           *AdminAPIConfig         `yaml:"admin_api,omitempty"`
-	PublicAPI          *PublicAPIConfig        `yaml:"public_api,omitempty"`
-	GRPC               *grpc.Config            `yaml:"grpc,omitempty"`
-	Sentry             *sentry.Config          `yaml:"sentry,omitempty"`
-	EventLog           *eventlog.StorageConfig `yaml:"event_log,omitempty"`
-	ManagementKeystore string                  `yaml:"management_keystore,omitempty" valid:"path"`
-	DNSFilter          *xdns.Config            `yaml:"dns_filter"`
+	ExternalStats      *extstat.Config             `yaml:"external_stats,omitempty"`
+	NetworkPolicy      *NetworkAccessPolicy        `yaml:"network,omitempty"`
+	SSL                *xhttp.SSLConfig            `yaml:"ssl,omitempty"`
+	Domain             *xhttp.DomainConfig         `yaml:"domain,omitempty"`
+	AdminAPI           *AdminAPIConfig             `yaml:"admin_api,omitempty"`
+	PublicAPI          *PublicAPIConfig            `yaml:"public_api,omitempty"`
+	GRPC               *grpc.Config                `yaml:"grpc,omitempty"`
+	Sentry             *sentry.Config              `yaml:"sentry,omitempty"`
+	EventLog           *eventlog.StorageConfig     `yaml:"event_log,omitempty"`
+	ManagementKeystore string                      `yaml:"management_keystore,omitempty" valid:"path"`
+	DNSFilter          *xdns.Config                `yaml:"dns_filter"`
+	PortRestrictions   *ipam.PortRestrictionConfig `yaml:"ports,omitempty"`
 
 	// path to the config file, or default path in case of safe defaults.
 	// Used to override config via the admin API.
@@ -78,6 +79,7 @@ func (s *Config) GetNetworkAccessPolicy() NetworkAccessPolicy {
 			Access: ipam.NetworkAccess{DefaultPolicy: ipam.AliasInternetOnly()},
 		}
 	}
+
 	return *s.NetworkPolicy
 }
 
@@ -283,6 +285,7 @@ func safeDefaults(rootDir string) *Config {
 		Wireguard:          wireguard.DefaultConfig(),
 		AdminAPI:           adminAPIConfig,
 		ManagementKeystore: keystorePath,
+		PortRestrictions:   ipam.DefaultPortRestrictions(),
 	}
 }
 

--- a/pkg/ipam/config.go
+++ b/pkg/ipam/config.go
@@ -21,21 +21,21 @@ const (
 	AccessPolicyAllowAll
 )
 
-type aliasToInt struct {
+type accessPolicy struct {
 	v int
 }
 
-func (atoi aliasToInt) Int() int { return atoi.v }
+func (policy accessPolicy) Int() int { return policy.v }
 
-func (atoi *aliasToInt) UnmarshalText(raw []byte) error {
+func (policy *accessPolicy) UnmarshalText(raw []byte) error {
 	s := string(raw)
 	switch s {
 	case "default":
-		atoi.v = AccessPolicyDefault
+		policy.v = AccessPolicyDefault
 	case "internet_only":
-		atoi.v = AccessPolicyInternetOnly
+		policy.v = AccessPolicyInternetOnly
 	case "allow_all":
-		atoi.v = AccessPolicyAllowAll
+		policy.v = AccessPolicyAllowAll
 	default:
 		return fmt.Errorf("unknown policy %s", s)
 	}
@@ -43,8 +43,8 @@ func (atoi *aliasToInt) UnmarshalText(raw []byte) error {
 	return nil
 }
 
-func (atoi aliasToInt) MarshalText() ([]byte, error) {
-	switch atoi.v {
+func (policy accessPolicy) MarshalText() ([]byte, error) {
+	switch policy.v {
 	case AccessPolicyDefault:
 		return []byte("default"), nil
 	case AccessPolicyInternetOnly:
@@ -52,20 +52,20 @@ func (atoi aliasToInt) MarshalText() ([]byte, error) {
 	case AccessPolicyAllowAll:
 		return []byte("allow_all"), nil
 	default:
-		return nil, fmt.Errorf("unknown policy %d", atoi.v)
+		return nil, fmt.Errorf("unknown policy %d", policy.v)
 	}
 }
 
-func AliasInternetOnly() aliasToInt {
-	return aliasToInt{v: AccessPolicyInternetOnly}
+func AliasInternetOnly() accessPolicy {
+	return accessPolicy{v: AccessPolicyInternetOnly}
 }
 
-func AliasAllowAll() aliasToInt {
-	return aliasToInt{v: AccessPolicyAllowAll}
+func AliasAllowAll() accessPolicy {
+	return accessPolicy{v: AccessPolicyAllowAll}
 }
 
 type NetworkAccess struct {
-	DefaultPolicy aliasToInt `yaml:"default_policy,omitempty"`
+	DefaultPolicy accessPolicy `yaml:"default_policy,omitempty"`
 }
 
 type RateLimiterConfig struct {

--- a/pkg/ipam/config_ports.go
+++ b/pkg/ipam/config_ports.go
@@ -1,0 +1,134 @@
+package ipam
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// Block ports from specified port range, allowing all others
+	RestrictionModeBlockList = iota
+	// Allow ports from specified port range, blocking all owhers
+	RestrictionModeAllowList
+)
+
+type ListMode struct {
+	v int
+}
+
+type PortRange struct {
+	low  uint16
+	high uint16
+}
+
+type ProtocolPortConfig struct {
+	Mode  ListMode    `yaml:"mode"`
+	Ports []PortRange `yaml:"range,omitempty"`
+}
+
+type PortRestrictionConfig struct {
+	UDP ProtocolPortConfig `yaml:"udp,omitempty"`
+	TCP ProtocolPortConfig `yaml:"tcp,omitempty"`
+}
+
+func DefaultPortRestrictions() *PortRestrictionConfig {
+	cfg := PortRestrictionConfig{}
+	cfg.UDP.Ports = []PortRange{
+		port(69),
+		port(113),
+		port(135),
+		portRange(137, 139),
+		port(445),
+		port(514),
+	}
+	cfg.TCP.Ports = []PortRange{
+		port(113),
+		port(445),
+	}
+
+	m, err := yaml.Marshal(cfg)
+	fmt.Println(m, err)
+
+	return &cfg
+}
+
+func (mode ListMode) Int() int { return mode.v }
+
+func (mode *ListMode) UnmarshalText(raw []byte) error {
+	s := string(raw)
+	switch s {
+	case "allow_list":
+		mode.v = RestrictionModeAllowList
+	case "block_list":
+		mode.v = RestrictionModeBlockList
+	default:
+		return fmt.Errorf("unknown mode %s", s)
+	}
+
+	return nil
+}
+
+func (mode ListMode) MarshalText() ([]byte, error) {
+	switch mode.v {
+	case RestrictionModeAllowList:
+		return []byte("allow_list"), nil
+	case RestrictionModeBlockList:
+		return []byte("block_list"), nil
+	default:
+		return nil, fmt.Errorf("unknown mode %d", mode.v)
+	}
+}
+
+func (rng *PortRange) UnmarshalText(raw []byte) error {
+	s := string(raw)
+	tuple_s := strings.Split(s, "-")
+	if len(tuple_s) > 2 || len(tuple_s) < 1 {
+		return fmt.Errorf("invalid range %s", s)
+	}
+
+	tuple := make([]uint16, len(tuple_s))
+	for idx, p_s := range tuple_s {
+		p, err := strconv.Atoi(strings.TrimSpace(p_s))
+		if err != nil {
+			return fmt.Errorf("invalid range %s", s)
+		}
+		if p < 0 || p > math.MaxUint16 {
+			return fmt.Errorf("invalid range %s", s)
+		}
+		tuple[idx] = uint16(p)
+	}
+
+	rng.low = tuple[0]
+	if len(tuple) == 1 {
+		rng.high = tuple[0]
+	} else {
+		rng.high = tuple[1]
+	}
+	return nil
+}
+
+func (rng PortRange) MarshalText() ([]byte, error) {
+	if rng.low == rng.high {
+		return []byte(fmt.Sprintf("%d", rng.low)), nil
+	} else {
+		return []byte(fmt.Sprintf("%d-%d", rng.low, rng.high)), nil
+	}
+}
+
+func portRange(low, high uint16) PortRange {
+	return PortRange{
+		low:  low,
+		high: high,
+	}
+}
+
+func port(port uint16) PortRange {
+	return PortRange{
+		low:  port,
+		high: port,
+	}
+}

--- a/pkg/ipam/config_ports.go
+++ b/pkg/ipam/config_ports.go
@@ -5,8 +5,6 @@ import (
 	"math"
 	"strconv"
 	"strings"
-
-	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -36,22 +34,30 @@ type PortRestrictionConfig struct {
 }
 
 func DefaultPortRestrictions() *PortRestrictionConfig {
-	cfg := PortRestrictionConfig{}
-	cfg.UDP.Ports = []PortRange{
-		port(69),
-		port(113),
-		port(135),
-		portRange(137, 139),
-		port(445),
-		port(514),
+	cfg := PortRestrictionConfig{
+		UDP: ProtocolPortConfig{
+			Mode: ListMode{
+				v: RestrictionModeBlockList,
+			},
+			Ports: []PortRange{
+				port(69),
+				port(113),
+				port(135),
+				portRange(137, 139),
+				port(445),
+				port(514),
+			},
+		},
+		TCP: ProtocolPortConfig{
+			Mode: ListMode{
+				v: RestrictionModeBlockList,
+			},
+			Ports: []PortRange{
+				port(113),
+				port(445),
+			},
+		},
 	}
-	cfg.TCP.Ports = []PortRange{
-		port(113),
-		port(445),
-	}
-
-	m, err := yaml.Marshal(cfg)
-	fmt.Println(m, err)
 
 	return &cfg
 }

--- a/pkg/ipam/config_ports.go
+++ b/pkg/ipam/config_ports.go
@@ -5,6 +5,8 @@ import (
 	"math"
 	"strconv"
 	"strings"
+
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -12,6 +14,11 @@ const (
 	RestrictionModeBlockList = iota
 	// Allow ports from specified port range, blocking all owhers
 	RestrictionModeAllowList
+)
+
+var (
+	protocolUDP protocolID = protocolID{name: "UDP", id: unix.IPPROTO_UDP}
+	protocolTCP protocolID = protocolID{name: "TCP", id: unix.IPPROTO_TCP}
 )
 
 type ListMode struct {
@@ -31,6 +38,11 @@ type ProtocolPortConfig struct {
 type PortRestrictionConfig struct {
 	UDP ProtocolPortConfig `yaml:"udp,omitempty"`
 	TCP ProtocolPortConfig `yaml:"tcp,omitempty"`
+}
+
+type protocolID struct {
+	name string
+	id   uint8
 }
 
 func DefaultPortRestrictions() *PortRestrictionConfig {

--- a/pkg/ipam/config_ports.go
+++ b/pkg/ipam/config_ports.go
@@ -56,7 +56,9 @@ func DefaultPortRestrictions() *PortRestrictionConfig {
 	return &cfg
 }
 
-func (mode ListMode) Int() int { return mode.v }
+func (mode ListMode) Int() int        { return mode.v }
+func (mode ListMode) BlockList() bool { return mode.v == RestrictionModeBlockList }
+func (mode ListMode) AllowList() bool { return mode.v == RestrictionModeAllowList }
 
 func (mode *ListMode) UnmarshalText(raw []byte) error {
 	s := string(raw)
@@ -72,15 +74,19 @@ func (mode *ListMode) UnmarshalText(raw []byte) error {
 	return nil
 }
 
-func (mode ListMode) MarshalText() ([]byte, error) {
+func (mode ListMode) String() string {
 	switch mode.v {
 	case RestrictionModeAllowList:
-		return []byte("allow_list"), nil
+		return "allow_list"
 	case RestrictionModeBlockList:
-		return []byte("block_list"), nil
+		return "block_list"
 	default:
-		return nil, fmt.Errorf("unknown mode %d", mode.v)
+		return "unknown"
 	}
+}
+
+func (mode ListMode) MarshalText() ([]byte, error) {
+	return []byte(mode.String()), nil
 }
 
 func (rng *PortRange) UnmarshalText(raw []byte) error {

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -32,10 +32,11 @@ type IPAM struct {
 }
 
 type Config struct {
-	Subnet       *xnet.IPNet
-	Interface    string
-	AccessPolicy NetworkAccess
-	RateLimiter  *RateLimiterConfig
+	Subnet           *xnet.IPNet
+	Interface        string
+	AccessPolicy     NetworkAccess
+	RateLimiter      *RateLimiterConfig
+	PortRestrictions *PortRestrictionConfig
 }
 
 func New(cfg Config) (*IPAM, error) {
@@ -86,6 +87,10 @@ func New(cfg Config) (*IPAM, error) {
 		if err := nf.newIsolateAllRule(cfg.Subnet); err != nil {
 			return nil, err
 		}
+	}
+
+	if cfg.PortRestrictions != nil {
+		nf.fillPortRestrictionRules(cfg.PortRestrictions)
 	}
 
 	return &IPAM{

--- a/pkg/ipam/netfilter.go
+++ b/pkg/ipam/netfilter.go
@@ -15,4 +15,5 @@ type netFilter interface {
 	newIsolatePeerRule(peerIP xnet.IP) error
 	newIsolateAllRule(ipNet *xnet.IPNet) error
 	findAndRemoveRule(id []byte) error
+	fillPortRestrictionRules(ports *PortRestrictionConfig) error
 }

--- a/pkg/ipam/nft_linux.go
+++ b/pkg/ipam/nft_linux.go
@@ -409,6 +409,7 @@ func (nft *netfilterWrapper) setBlockedPorts4proto(ports []PortRange, proto int,
 		Name:      nftNextSetName(),
 		Anonymous: true,
 		Constant:  true,
+		Interval:  true,
 		KeyType:   nftables.TypeInetService,
 	}
 
@@ -427,11 +428,14 @@ func (nft *netfilterWrapper) setBlockedPorts4proto(ports []PortRange, proto int,
 
 		highest = r.high
 
-		for p := r.low; p <= r.high; p++ {
-			setElements = append(setElements, nftables.SetElement{
-				Key: nftUint16ToKey(p),
-			})
-		}
+		setElements = append(setElements, nftables.SetElement{
+			Key: nftUint16ToKey(r.low),
+		})
+		setElements = append(setElements, nftables.SetElement{
+			Key:         nftUint16ToKey(r.high + 1),
+			IntervalEnd: true,
+		})
+
 	}
 
 	if err := nft.c.AddSet(&set, setElements); err != nil {

--- a/pkg/ipam/nft_linux.go
+++ b/pkg/ipam/nft_linux.go
@@ -389,7 +389,7 @@ func (nft *netfilterWrapper) setBlockedPorts4proto(ports []PortRange, proto int,
 			&expr.Cmp{
 				Op:       expr.CmpOpEq,
 				Register: 1,
-				Data:     []byte{unix.IPPROTO_TCP},
+				Data:     []byte{byte(proto)},
 			},
 			&expr.Payload{
 				DestRegister: 1,
@@ -414,8 +414,6 @@ func (nft *netfilterWrapper) setBlockedPorts4proto(ports []PortRange, proto int,
 }
 
 func (nft *netfilterWrapper) fillPortRestrictionRules(ports *PortRestrictionConfig) error {
-	defer listNFTObjects(nft.c)
-
 	zap.L().Debug("Blocking ports", zap.Any("ports", ports))
 	err := nft.setBlockedPorts4proto(ports.UDP.Ports, unix.IPPROTO_UDP, ports.UDP.Mode)
 	if err != nil {

--- a/pkg/ipam/nft_linux.go
+++ b/pkg/ipam/nft_linux.go
@@ -148,7 +148,15 @@ func (nft *netfilterWrapper) initTable(table *nftables.Table, chain *nftables.Ch
 
 func (nft *netfilterWrapper) initPortfilterTable(table *nftables.Table, chain *nftables.Chain) {
 	nft.initTable(table, chain)
-	nft.addCtMatchRule(table, chain, []uint32{expr.CtStateBitESTABLISHED}, &expr.Verdict{Kind: expr.VerdictAccept})
+	nft.addCtMatchRule(
+		table,
+		chain,
+		[]uint32{
+			expr.CtStateBitESTABLISHED,
+			expr.CtStateBitRELATED,
+		},
+		&expr.Verdict{Kind: expr.VerdictAccept},
+	)
 
 }
 func (nft *netfilterWrapper) newIsolatePeerRule(peerIP xnet.IP) error {


### PR DESCRIPTION
Introduce blocking TCP and UDP ports. Default configuration is:
```
ports:
    udp:
        mode: block_list
        range:
            - "69"
            - "113"
            - "135"
            - "137-139"
            - "445"
            - "514"
    tcp:
        mode: block_list
        range:
            - "53"
            - "113"
            - "445"
```
Possible modes are `block_list` and `allow_list`. In `block_list` mode all specified in list ports are blocked and all other are passed. In `allow_list` mode vice versa: all specified ports are allowed, but others are not.